### PR TITLE
Allow using symfony 4.3 and a few other newer dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
         }
     ],
     "require": {
-        "symfony/symfony": "~2.5|~3.0",
-        "sensio/framework-extra-bundle": "~3.0",
-        "gedmo/doctrine-extensions": "~2.0"
+        "symfony/symfony": "~2.5|~3.0|~4.3",
+        "sensio/framework-extra-bundle": "~3.0|~5.0",
+        "gedmo/doctrine-extensions": "~2.0|~2.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.2",
-        "doctrine/orm": "~2.2,>=2.2.3",
-        "doctrine/doctrine-bundle": "~1.2",
-        "symfony/monolog-bundle": "~2",
-        "symfony/swiftmailer-bundle": "~2.3"
+        "phpunit/phpunit": "~4.2|~5.4",
+        "doctrine/orm": "~2.2,>=2.2.3|~2.6",
+        "doctrine/doctrine-bundle": "~1.2|~2.0|~2.1",
+        "symfony/monolog-bundle": "~2|~3.5",
+        "symfony/swiftmailer-bundle": "~2.3|~3.4"
     },
     "autoload": {
         "psr-4": {"Abc\\Bundle\\SequenceBundle\\": ""}


### PR DESCRIPTION
I have verified with `composer install` that symfony 4.3 and framework-extra-bundle 5.0 is installed.